### PR TITLE
updates README to make instructions flasky be less cohort specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The goals of this live code are to:
 
 The features described in each wave of this live code are intended to work with the Flasky back-end created during C16. Your instructors will be using a version of the Flasky back end specific to your cohort. While the underlying structure will follow the same general pattern, some of the specific features or model names may differ.
 
-To follow along, clone the cohort-specific repository of Flasky that your instructors provide. This will allow you to run the same back end locally that will be used during the live code.
+To follow along, clone the cohort-specific repository of Flasky that your instructors provide. This allows you to run the same version of the back end used during the live codes on your machine.
 
 **Note: Though your cohort may use not have a(n) object/model `Dog`, the React skills you’ll be practicing remain the same regardless of the back-end details.**
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ The goals of this live code are to:
 
 ## Flasky Back End
 
-The features described in each wave of this live code were designed to be used with the Flasky back-end created during C16. The source code for this Flasky can be found [here](https://github.com/adagold/flasky/tree/solution) and the deployed version can be found [here](https://ada-flasky.onrender.com).
+The features described in each wave of this live code are intended to work with the Flasky back-end created during C16. Your instructors will be using a version of the Flasky back end specific to your cohort. While the underlying structure will follow the same general pattern, some of the specific features or model names may differ.
 
-Your instructors may use the Flasky Back End created for your cohort and your homeroom class. Thus, the exact features they implement may be different from those described below. The React skills practice will be the same regardless of the exact features your class implements. 
+To follow along, clone the cohort-specific repository of Flasky that your instructors provide. This will allow you to run the same back end locally that will be used during the live code.
+
+**Note: Though your cohort may use not have a(n) object/model `Dog`, the React skills you’ll be practicing remain the same regardless of the back-end details.**
 
 ## Wave 00: Components and Props
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The goals of this live code are to:
 
 ## Flasky Back End
 
-The features described in each wave of this live code are intended to work with the Flasky back-end created during C16. Your instructors will be using a version of the Flasky back end specific to your cohort. While the underlying structure will follow the same general pattern, some of the specific features or model names may differ.
+The features described in each wave of this live code are intended to work with the Flasky back-end created during C16. Your instructors will be using a version of the Flasky back end specific to your cohort. The underlying structure will follow the same pattern that we see in the directions, but some of the specific features or model names for your cohort's version may differ from what's described in the directions.
 
 To follow along, clone the cohort-specific repository of Flasky that your instructors provide. This allows you to run the same version of the back end used during the live codes on your machine.
 


### PR DESCRIPTION
[Asana Ticket](https://app.asana.com/1/181459410160484/project/1205655776549324/task/1206697443678564?focus=true)

PR to: 
- remove flasky solution branch and deployed version links
- add info on cloning down cohort branch locally for a back end
- add info instructors will be working off the cohort flasky backend and that the object and list models will be the same used in your class which may differ from `dog` used in the instructions